### PR TITLE
added instagram query for sdk version 30 and above

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <queries>
+        <package android:name="com.instagram.android" />
+    </queries>
     <application>
         <provider
             android:name=".util.ShareFileProvider"


### PR DESCRIPTION
Android 11 changes how apps can query and interact with other apps that the user has installed on a device. Thus the method instagramInstalled() was returning false even when Instagram was installed on the device. adding query for perticular app fixes that problem.